### PR TITLE
修改

### DIFF
--- a/src/main/java/tk/mybatis/mapper/util/StringUtil.java
+++ b/src/main/java/tk/mybatis/mapper/util/StringUtil.java
@@ -94,7 +94,8 @@ public class StringUtil {
             if (isUppercaseAlpha(c)) {
                 sb.append('_').append(toLowerAscii(c));
             } else {
-                sb.append(toUpperAscii(c));
+                //sb.append(toUpperAscii(c));
+                sb.append(c);//非大写不加下划线，直接copy,不用uppercase
             }
         }
         return sb.charAt(0) == '_' ? sb.substring(1) : sb.toString();


### PR DESCRIPTION
camelhump规则,将驼峰风格替换为下划线风格时，字母都会变成大写的问题。
这个种替换应该是camelhumpAndUppercase, 而不是camelhump,这种规则