### PR TITLE
Bugfix CamelUpperCase : (userId -> user_id) instead of (userId ->USER_iD)

### DIFF
--- a/src/main/java/tk/mybatis/mapper/util/StringUtil.java
+++ b/src/main/java/tk/mybatis/mapper/util/StringUtil.java
@@ -94,7 +94,7 @@ public class StringUtil {
             if (isUppercaseAlpha(c)) {
                 sb.append('_').append(toLowerAscii(c));
             } else {
-                sb.append(toUpperAscii(c));
+                sb.append(c);
             }
         }
         return sb.charAt(0) == '_' ? sb.substring(1) : sb.toString();


### PR DESCRIPTION
开启驼峰转换，和当当的SharingJDBC整合时发现一个奇怪的问题：
userId转换后变成成USER_iD而不是user_id
虽然mysql不区分大小写，但SharingJDBC分库分表键是严格区分大小小的
所以解决方案就变成
1.实体类添加Column注解，指定user_id
或者
2.SharingJDBC中分库分表键,写成USER_iD
这两种解决方案都不是十分优雅。

所以去看了下源代码
tk.mybatis.mapper.util.StringUtil这个类的camelhumpToUnderline方法，修改下就行
97行
sb.append(toUpperAscii(c));
改成
sb.append(c);