### PR TITLE
update to mybatis-generator-core:v1.3.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.mybatis.generator</groupId>
             <artifactId>mybatis-generator-core</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.4</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/tk/mybatis/mapper/generator/MapperCommentGenerator.java
+++ b/src/main/java/tk/mybatis/mapper/generator/MapperCommentGenerator.java
@@ -222,4 +222,16 @@ public class MapperCommentGenerator implements CommentGenerator {
      */
     public void addClassComment(InnerClass innerClass, IntrospectedTable introspectedTable, boolean markAsDoNotDelete) {
     }
+
+    /**
+     * 升级到 mybatis-generator-core v1.3.4 接口变化
+     * TODO: 待增加可能值得增加的相关注释修改
+     *
+     * @param topLevelClass
+     * @param introspectedTable
+     */
+    @Override
+    public void addModelClassComment(TopLevelClass topLevelClass, IntrospectedTable introspectedTable) {
+
+    }
 }


### PR DESCRIPTION
相关的 mybatis/generator 项目从1.3.2以来重要的更新见其 release 列表页。
升级改动仅一处，验证通过。

这个更新解决了 #42 问题，即升级到新版本的接口增加一处。

升级到新版本很有必要，从 1.3.2 以来的更新我发现的问题解决已有例如以下一些，见：
https://github.com/mybatis/generator/issues?q=milestone%3A1.3.3+is%3Aclosed
https://github.com/mybatis/generator/issues?q=milestone%3A1.3.4+is%3Aclosed

* 生成 sql map 中的 resultMap 项属性顺序时有变化的问题：

> Generator sometimes generates slightly different but functionally equivalent xml (adds/removes spaces, swaps properties) bug

更多问题描述见： https://groups.google.com/forum/#!topic/mybatis-user/yX3w-wJISxE 。解决后，生成的 xml 文件已稳定不变，不过有一点特别提醒，**升级到1.3.4新版本后，@mbggenerated 标签已改为：@mbg.generated，所以旧生成的 xml mapper 文件如果已有自定义内容，在更新后重新生成时要做好备份再操作，以免内容丢失**

* 生成时可能有换行符问题

> Eclipse plugin:'CRLF' will be replaced by 'LF' when xml file need merge

以上两种情况都会造成像 git 更新出现不必要修改/提交。此外还有不少增强的功能，所以尽早升级