### PR TITLE
为方法selectProperties()和excludeProperties()添加指定字段的合法性检查

### DIFF
--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -29,8 +29,10 @@ import org.apache.ibatis.reflection.SystemMetaObject;
 import org.apache.ibatis.type.TypeHandler;
 import tk.mybatis.mapper.MapperException;
 import tk.mybatis.mapper.mapperhelper.EntityHelper;
+import tk.mybatis.mapper.mapperhelper.FieldHelper;
 import tk.mybatis.mapper.util.StringUtil;
 
+import javax.persistence.Transient;
 import java.util.*;
 
 /**
@@ -145,6 +147,14 @@ public class Example implements IDynamicTableName {
             for (String property : properties) {
                 if (propertyMap.containsKey(property)) {
                     this.selectColumns.add(propertyMap.get(property).getColumn());
+                } else {
+                    List<EntityField> fields = FieldHelper.getFields(entityClass);
+                    for (EntityField field : fields) {
+                        if (field.isAnnotationPresent(Transient.class) && property.equals(field.getName())) {
+                            throw new MapperException("类 " + entityClass.getSimpleName() + " 的属性 \'" + property + "\' 被 @Transient 注释所修饰，不能指定为查询字段");
+                        }
+                    }
+                    throw new MapperException("类 " + entityClass.getSimpleName() + " 不包含属性 \'" + property + "\'");
                 }
             }
         }

--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -127,6 +127,8 @@ public class Example implements IDynamicTableName {
             for (String property : properties) {
                 if (propertyMap.containsKey(property)) {
                     this.excludeColumns.add(propertyMap.get(property).getColumn());
+                } else {
+                    throw new MapperException("类 " + entityClass.getSimpleName() + " 不包含属性 \'" + property + "\'，或该属性被@Transient注释！");
                 }
             }
         }
@@ -148,13 +150,7 @@ public class Example implements IDynamicTableName {
                 if (propertyMap.containsKey(property)) {
                     this.selectColumns.add(propertyMap.get(property).getColumn());
                 } else {
-                    List<EntityField> fields = FieldHelper.getFields(entityClass);
-                    for (EntityField field : fields) {
-                        if (field.isAnnotationPresent(Transient.class) && property.equals(field.getName())) {
-                            throw new MapperException("类 " + entityClass.getSimpleName() + " 的属性 \'" + property + "\' 被 @Transient 注释所修饰，不能指定为查询字段");
-                        }
-                    }
-                    throw new MapperException("类 " + entityClass.getSimpleName() + " 不包含属性 \'" + property + "\'");
+                    throw new MapperException("类 " + entityClass.getSimpleName() + " 不包含属性 \'" + property + "\'，或该属性被@Transient注释！");
                 }
             }
         }

--- a/src/test/java/tk/mybatis/mapper/test/example/TestSelectByExample.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestSelectByExample.java
@@ -203,6 +203,8 @@ public class TestSelectByExample {
 
     @Test
     public void testSelectColumnsByExample() {
+        exception.expect(MapperException.class);
+        exception.expectMessage("类 Country 不包含属性 'hehe'，或该属性被@Transient注释！");
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
@@ -302,7 +304,7 @@ public class TestSelectByExample {
     @Test
     public void testSelectPropertisCheckSpellWrong() {
         exception.expect(MapperException.class);
-        exception.expectMessage("类 Country 不包含属性 'countrymame'");
+        exception.expectMessage("类 Country 不包含属性 'countrymame'，或该属性被@Transient注释！");
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
@@ -324,7 +326,7 @@ public class TestSelectByExample {
     @Test
     public void testSelectPropertisCheckTransient1() {
         exception.expect(MapperException.class);
-        exception.expectMessage("类 Country 的属性 'name' 被 @Transient 注释所修饰，不能指定为查询字段");
+        exception.expectMessage("类 Country 不包含属性 'name'，或该属性被@Transient注释！");
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
@@ -343,7 +345,7 @@ public class TestSelectByExample {
     @Test
     public void testSelectPropertisCheckTransient2() {
         exception.expect(MapperException.class);
-        exception.expectMessage("类 Country 的属性 'dynamicTableName123' 被 @Transient 注释所修饰，不能指定为查询字段");
+        exception.expectMessage("类 Country 不包含属性 'dynamicTableName123'，或该属性被@Transient注释！");
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
@@ -355,4 +357,43 @@ public class TestSelectByExample {
             sqlSession.close();
         }
     }
+
+    /**
+     * 指定排除的查询字段不存在或拼写错误
+     */
+    @Test
+    public void testExcludePropertisCheckWrongSpell() {
+        exception.expect(MapperException.class);
+        exception.expectMessage("类 Country 不包含属性 'countrymame'，或该属性被@Transient注释！");
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = new Example(Country.class);
+            example.excludeProperties(new String[]{"countrymame"});
+            example.createCriteria().andEqualTo("id", 35);
+            List<Country> country = mapper.selectByExample(example);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    /**
+     * 指定排除的查询字段为@Transient注释字段
+     */
+    @Test
+    public void testExcludePropertisCheckTransient() {
+        exception.expect(MapperException.class);
+        exception.expectMessage("类 Country 不包含属性 'dynamicTableName123'，或该属性被@Transient注释！");
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = new Example(Country.class);
+            example.excludeProperties(new String[]{"dynamicTableName123"});
+            example.createCriteria().andEqualTo("id", 35);
+            List<Country> country = mapper.selectByExample(example);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
 }


### PR DESCRIPTION
Motivation:
目前的方法selectProperties(String... properties)和excludeProperties(String... properties)没有对用户指定的查询字段进行合法性检查，而是直接抛弃未匹配的property：
```
for (String property : properties) {
    if (propertyMap.containsKey(property)) {
        this.selectColumns.add(propertyMap.get(property).getColumn());
    }
}
```
如果用户期望查询字段**contryname**，而误拼写成了**contrymame**，则返回值contry.getContryname()为**null**。如果用户没有注意到拼写错误的话，这样的错误很难发现。
同时，用户也可能误操作指定用Transient注释的字段（假如用户对Transient注释的字段作用不清楚）

Modification:
- 以方法selectProperties()为例：
  当用户指定的查询字段为Transient注释所修饰时，抛出异常，并提示该指定字段为Transient修饰字段；
  当用户指定的查寻字段既不在propertyMap中，又没有被Transient注释所修饰，则抛出异常，并提示该字段在该类中不存在。
- 添加单元测试

Result:
以方法selectProperties()为例：
Before: 当用户指定的查询字段为Transient注释所修饰或在类中不存在时，selectProperties()不抛弃这些字段，并可以继续执行selectByExample(example)方法。
After：当用户指定的查询字段为Transient注释所修饰或在类中不存在时，selectProperties()抛出异常，程序终止，selectByExample(example)方法不被执行。