### PR TITLE
@Deprecated excludeProperties()

### DIFF
--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -116,7 +116,9 @@ public class Example implements IDynamicTableName {
      *
      * @param properties 属性名的可变参数
      * @return
+     * @Deprecated 在与selectProperties一起使用时，起不到任何作用
      */
+    @Deprecated
     public Example excludeProperties(String... properties) {
         if (properties != null && properties.length > 0) {
             if (this.excludeColumns == null) {


### PR DESCRIPTION
Motivation:
excludeProperties()方法在和selectProperties()方法一起使用时，没有作用。
且遵循SQL的查询逻辑，excludeProperties()方法的使用还是偏少。

Modification：
Deprecated excludeProperties()方法