### PR TITLE
用builder模式构造Example

### DIFF
--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -117,8 +117,11 @@ public class Example implements IDynamicTableName {
         this.selectColumns = builder.selectColumns;
         this.excludeColumns = builder.excludeColumns;
         this.oredCriteria = builder.exampleCriterias;
-        this.orderByClause = builder.orderByClause.toString();
         this.forUpdate = builder.forUpdate;
+
+        if (!StringUtil.isEmpty(builder.orderByClause.toString())) {
+            this.orderByClause = builder.orderByClause.toString();
+        }
     }
 
     public static Builder builder(Class<?> entityClass) {
@@ -997,6 +1000,8 @@ public class Example implements IDynamicTableName {
                 for (String property : properties) {
                     if (this.propertyMap.containsKey(property)) {
                         this.selectColumns.add(propertyMap.get(property).getColumn());
+                    } else {
+                        throw new MapperException("当前实体类不包含名为" + property + "的属性!");
                     }
                 }
             }
@@ -1011,6 +1016,8 @@ public class Example implements IDynamicTableName {
                 for (String property : properties) {
                     if (propertyMap.containsKey(property)) {
                         this.excludeColumns.add(propertyMap.get(property).getColumn());
+                    } else {
+                        throw new MapperException("当前实体类不包含名为" + property + "的属性!");
                     }
                 }
             }
@@ -1092,8 +1099,6 @@ public class Example implements IDynamicTableName {
 
             if (this.orderByClause.length() > 0) {
                 this.orderByClause = new StringBuilder(this.orderByClause.substring(1, this.orderByClause.length()));
-            } else {
-                this.orderByClause.append("id desc");
             }
 
             return new Example(this);

--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -118,6 +118,7 @@ public class Example implements IDynamicTableName {
         this.excludeColumns = builder.excludeColumns;
         this.oredCriteria = builder.exampleCriterias;
         this.forUpdate = builder.forUpdate;
+        this.tableName = builder.tableName;
 
         if (!StringUtil.isEmpty(builder.orderByClause.toString())) {
             this.orderByClause = builder.orderByClause.toString();

--- a/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -114,7 +114,8 @@ public class Example implements IDynamicTableName {
         this.entityClass = builder.entityClass;
         this.propertyMap = builder.propertyMap;
         this.oredCriteria = builder.exampleCriterias;
-        this.ORDERBY = new OrderBy(this, propertyMap);
+        this.orderByClause = builder.orderByClause.toString();
+        this.forUpdate = builder.forUpdate;
     }
 
     public static Builder builder(Class<?> entityClass) {
@@ -910,10 +911,8 @@ public class Example implements IDynamicTableName {
         this.tableName = tableName;
     }
 
-
-
     public static class Builder {
-        private String orderByClause;
+        private StringBuilder orderByClause;
 
         private boolean distinct;
 
@@ -957,15 +956,16 @@ public class Example implements IDynamicTableName {
             this.entityClass = entityClass;
             this.exists = exists;
             this.notNull = notNull;
+            this.orderByClause = new StringBuilder();
             this.table = EntityHelper.getEntityTable(entityClass);
             this.propertyMap = table.getPropertyMap();
             this.sqlsCriteria = new ArrayList<Sqls.Criteria>(2);
         }
 
-        public Builder setOrderByClause(String orderByClause) {
-            this.orderByClause = orderByClause;
-            return this;
-        }
+//        public Builder setOrderByClause(String orderByClause) {
+//            this.orderByClause = orderByClause;
+//            return this;
+//        }
 
         public Builder distinct() {
             return setDistinct(true);
@@ -1001,7 +1001,7 @@ public class Example implements IDynamicTableName {
             return this;
         }
 
-        public Builder fromTable(String tableName) {
+        public Builder from(String tableName) {
             return setTableName(tableName);
         }
 
@@ -1031,6 +1031,33 @@ public class Example implements IDynamicTableName {
             return  this;
         }
 
+        public Builder orderBy(String... properties) {
+            return orderByAsc(properties);
+        }
+
+        public Builder orderByAsc(String... properties) {
+            contactOrderByClause(" Asc", properties);
+            return this;
+        }
+
+        public Builder orderByDesc(String... properties) {
+            contactOrderByClause(" Desc", properties);
+            return this;
+        }
+
+        private void contactOrderByClause(String order, String... properties) {
+            StringBuilder columns = new StringBuilder();
+            for (String property : properties) {
+                String column;
+                if ((column = propertyforOderBy(property)) != null) {
+                    columns.append(",").append(column);
+                }
+            }
+            columns.append(order);
+            if (columns.length() > 0) {
+                orderByClause.append(columns);
+            }
+        }
 
         public Example build() {
             this.exampleCriterias = new ArrayList<Criteria>();
@@ -1045,6 +1072,10 @@ public class Example implements IDynamicTableName {
                     transformCriterion(exampleCriteria, condition, property, values, andOr);
                 }
                 exampleCriterias.add(exampleCriteria);
+            }
+
+            if (this.orderByClause.length() > 0) {
+                this.orderByClause = new StringBuilder(this.orderByClause.substring(1, this.orderByClause.length()));
             }
 
             Example innerExample =  new Example(this);
@@ -1094,6 +1125,17 @@ public class Example implements IDynamicTableName {
             } else {
                 return null;
             }
+        }
+
+        private String propertyforOderBy(String property) {
+            if (StringUtil.isEmpty(property) || StringUtil.isEmpty(property.trim())) {
+                throw new MapperException("接收的property为空！");
+            }
+            property = property.trim();
+            if (!propertyMap.containsKey(property)) {
+                throw new MapperException("当前实体类不包含名为" + property + "的属性!");
+            }
+            return propertyMap.get(property).getColumn();
         }
     }
 }

--- a/src/main/java/tk/mybatis/mapper/util/Sqls.java
+++ b/src/main/java/tk/mybatis/mapper/util/Sqls.java
@@ -1,0 +1,248 @@
+package tk.mybatis.mapper.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author wuyi
+ * @date 2017/11/18
+ */
+public class Sqls {
+    private Criteria criteria;
+
+    private Sqls() {
+        this.criteria = new Criteria();
+    }
+
+    public static Sqls custom() {
+        return new Sqls();
+    }
+
+    public Criteria getCriteria() {
+        return criteria;
+    }
+
+    public Sqls andIsNull(String property) {
+        this.criteria.criterions.add(new Criterion(property, "is null", "and"));
+        return this;
+    }
+
+    public Sqls andIsNotNull(String property) {
+        this.criteria.criterions.add(new Criterion(property, "is not null", "and"));
+        return this;
+    }
+
+    public Sqls andEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "=", "and"));
+        return this;
+    }
+
+    public Sqls andNotEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<>", "and"));
+        return this;
+    }
+
+    public Sqls andGreaterThan(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, ">", "and"));
+        return this;
+    }
+
+    public Sqls andGreaterThanOrEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, ">=", "and"));
+        return this;
+    }
+
+
+    public Sqls andLessThan(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<", "and"));
+        return this;
+    }
+
+    public Sqls andLessThanOrEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<=", "and"));
+        return this;
+    }
+
+    public Sqls andIn(String property, Iterable values) {
+        this.criteria.criterions.add(new Criterion(property, values, "in", "and"));
+        return this;
+    }
+
+    public Sqls andNotIn(String property, Iterable values) {
+        this.criteria.criterions.add(new Criterion(property, values, "not in", "and"));
+        return this;
+    }
+
+    public Sqls andBetween(String property, Object value1, Object value2) {
+        this.criteria.criterions.add(new Criterion(property, value1, value2, "between", "and"));
+        return this;
+    }
+
+    public Sqls andNotBetween(String property, Object value1, Object value2) {
+        this.criteria.criterions.add(new Criterion(property, value1, value2, "not between", "and"));
+        return this;
+    }
+
+    public Sqls andLike(String property, String value) {
+        this.criteria.criterions.add(new Criterion(property, value, "like", "and"));
+        return this;
+    }
+
+    public Sqls andNotLike(String property, String value) {
+        this.criteria.criterions.add(new Criterion(property, value, "not like", "and"));
+        return this;
+    }
+
+
+    public Sqls orIsNull(String property) {
+        this.criteria.criterions.add(new Criterion(property, "is null", "or"));
+        return this;
+    }
+
+    public Sqls orIsNotNull(String property) {
+        this.criteria.criterions.add(new Criterion(property, "is not null", "or"));
+        return this;
+    }
+
+
+    public Sqls orEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "=", "or"));
+        return this;
+    }
+
+    public Sqls orNotEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<>", "or"));
+        return this;
+    }
+
+    public Sqls orGreaterThan(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, ">", "or"));
+        return this;
+    }
+
+    public Sqls orGreaterThanOrEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, ">=", "or"));
+        return this;
+    }
+
+    public Sqls orLessThan(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<", "or"));
+        return this;
+    }
+
+    public Sqls orLessThanOrEqualTo(String property, Object value) {
+        this.criteria.criterions.add(new Criterion(property, value, "<=", "or"));
+        return this;
+    }
+
+    public Sqls orIn(String property, Iterable values) {
+        this.criteria.criterions.add(new Criterion(property, values, "in", "or"));
+        return this;
+    }
+
+    public Sqls orNotIn(String property, Iterable values) {
+        this.criteria.criterions.add(new Criterion(property, values, "not in", "or"));
+        return this;
+    }
+
+    public Sqls orBetween(String property, Object value1, Object value2) {
+        this.criteria.criterions.add(new Criterion(property, value1, value2, "between", "or"));
+        return this;
+    }
+
+    public Sqls orNotBetween(String property, Object value1, Object value2) {
+        this.criteria.criterions.add(new Criterion(property, value1, value2, "not between", "or"));
+        return this;
+    }
+
+    public Sqls orLike(String property, String value) {
+        this.criteria.criterions.add(new Criterion(property, value, "like", "or"));
+        return this;
+    }
+
+    public Sqls orNotLike(String property, String value) {
+        this.criteria.criterions.add(new Criterion(property, value, "not like", "or"));
+        return this;
+    }
+
+    public static class Criteria {
+        private String andOr;
+        private List<Criterion> criterions;
+        public Criteria() {
+            this.criterions = new ArrayList<Criterion>(2);
+        }
+
+        public List<Criterion> getCriterions() {
+            return criterions;
+        }
+
+        public String getAndOr() {
+            return andOr;
+        }
+
+        public void setAndOr(String andOr) {
+            this.andOr = andOr;
+        }
+    }
+
+    public static class Criterion {
+        private String property;
+        private Object value;
+        private Object secondValue;
+        private String condition;
+        private String andOr;
+
+        public Criterion(String property, String condition, String andOr) {
+            this.property = property;
+            this.condition = condition;
+            this.andOr = andOr;
+        }
+
+
+        public Criterion(String property, Object value, String condition, String andOr) {
+            this.property = property;
+            this.value = value;
+            this.condition = condition;
+            this.andOr = andOr;
+        }
+
+        public Criterion(String property, Object value1, Object value2, String condition, String andOr) {
+            this.property = property;
+            this.value = value1;
+            this.secondValue = value2;
+            this.condition = condition;
+            this.andOr = andOr;
+        }
+
+        public String getProperty() {
+            return property;
+        }
+
+        public Object getValue() {
+            return value;
+        }
+
+        public Object getSecondValue() {
+            return secondValue;
+        }
+
+        public Object[] getValues() {
+            if (value !=null) {
+                if (secondValue != null) {
+                    return new Object[]{value, secondValue};
+                } else {
+                    return new Object[] {value};
+                }
+            } else {
+                return new Object[]{};
+            }
+        }
+        public String getCondition() {
+            return condition;
+        }
+
+        public String getAndOr() {
+            return andOr;
+        }
+    }
+}

--- a/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -1,0 +1,180 @@
+package tk.mybatis.mapper.test.example;
+
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Assert;
+import org.junit.Test;
+import tk.mybatis.mapper.entity.Example;
+import tk.mybatis.mapper.mapper.CountryMapper;
+import tk.mybatis.mapper.mapper.MybatisHelper;
+import tk.mybatis.mapper.model.Country;
+import tk.mybatis.mapper.util.Sqls;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author wuyi
+ * @date 2017/11/18
+ */
+public class TestExampleBuilder {
+
+    @Test
+    public void testExampleBuilder() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class).build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(183, countries.size());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+
+    @Test
+    public void testEqualTo() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom().andEqualTo("id", "35"))
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Country country = countries.get(0);
+            Assert.assertEquals(Integer.valueOf(35), country.getId());
+            Assert.assertEquals("China", country.getCountryname());
+            Assert.assertEquals("CN", country.getCountrycode());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testBetween() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom().andBetween("id", 34, 35))
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Country country35 = countries.get(0);
+            Assert.assertEquals(Integer.valueOf(35), country35.getId());
+            Assert.assertEquals("China", country35.getCountryname());
+            Assert.assertEquals("CN", country35.getCountrycode());
+
+            Country country34 = countries.get(1);
+            Assert.assertEquals(Integer.valueOf(34), country34.getId());
+            Assert.assertEquals("Chile", country34.getCountryname());
+            Assert.assertEquals("CL", country34.getCountrycode());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testIn() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom().andIn("id", new ArrayList<Integer>(Arrays.asList(35, 183))))
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Country country35 = countries.get(1);
+            Assert.assertEquals(Integer.valueOf(35), country35.getId());
+            Assert.assertEquals("China", country35.getCountryname());
+            Assert.assertEquals("CN", country35.getCountrycode());
+
+            Country country183 = countries.get(0);
+            Assert.assertEquals(Integer.valueOf(183), country183.getId());
+            Assert.assertEquals("Zambia", country183.getCountryname());
+            Assert.assertEquals("ZM", country183.getCountrycode());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testCompound() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom()
+                            .andEqualTo("countryname", "China")
+                            .andEqualTo("id", 35)
+                            .orIn("id", new ArrayList<Integer>(Arrays.asList(35, 183)))
+                            .orLike("countryname","Ye%")
+                    )
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Country country35 = countries.get(2);
+            Assert.assertEquals(Integer.valueOf(35), country35.getId());
+            Assert.assertEquals("China", country35.getCountryname());
+            Assert.assertEquals("CN", country35.getCountrycode());
+
+            Country country183 = countries.get(0);
+            Assert.assertEquals(Integer.valueOf(183), country183.getId());
+            Assert.assertEquals("Zambia", country183.getCountryname());
+            Assert.assertEquals("ZM", country183.getCountrycode());
+
+            Country country179 = countries.get(1);
+            Assert.assertEquals(Integer.valueOf(179), country179.getId());
+            Assert.assertEquals("Yemen", country179.getCountryname());
+            Assert.assertEquals("YE", country179.getCountrycode());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testWhereAndWhereCompound() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom()
+                            .andEqualTo("countryname", "China")
+                            .andEqualTo("id", 35)
+                    )
+                    .andWhere(Sqls.custom()
+                                .andEqualTo("id", 183)
+                    )
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(0, countries.size());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testWhereOrWhereCompound() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom()
+                            .andEqualTo("countryname", "China")
+                            .andEqualTo("id", 35)
+                    )
+                    .orWhere(Sqls.custom()
+                            .andEqualTo("id", 183)
+                    )
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(2, countries.size());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+}

--- a/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -58,6 +58,24 @@ public class TestExampleBuilder {
     }
 
     @Test
+    public void testForUpdate() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .select("countryname")
+                    .where(Sqls.custom().andGreaterThan("id", 100))
+                    .orderByAsc("countrycode")
+                    .forUpdate()
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(83, countries.size());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
     public void testEqualTo() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
@@ -123,9 +141,11 @@ public class TestExampleBuilder {
             sqlSession.close();
         }
     }
-
+    /*
+    * @description: 单个where组合查询测试
+    * */
     @Test
-    public void testCompound() {
+    public void testWhereCompound0() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
@@ -158,6 +178,30 @@ public class TestExampleBuilder {
         }
     }
 
+    /*
+     * @description: 单个where组合查询测试
+     * */
+    @Test
+    public void testWhereCompound1() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom()
+                        .andBetween("id", 35, 50)
+                        .orLessThan("id", 40)
+                        .orIsNull("countryname")
+                    )
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(50, countries.size());
+        } finally {
+            sqlSession.close();
+        }
+    }
+    /*
+    *   @description: 多个where连接的查询语句
+    * */
     @Test
     public void testWhereAndWhereCompound() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();

--- a/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -141,11 +141,11 @@ public class TestExampleBuilder {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
             Example example = Example.builder(Country.class)
                     .where(Sqls.custom()
-                            .andEqualTo("countryname", "China")
-                            .andEqualTo("id", 35)
+                        .andEqualTo("countryname", "China")
+                        .andEqualTo("id", 35)
                     )
                     .andWhere(Sqls.custom()
-                                .andEqualTo("id", 183)
+                        .andEqualTo("id", 183)
                     )
                     .build();
             List<Country> countries = mapper.selectByExample(example);
@@ -173,6 +173,29 @@ public class TestExampleBuilder {
             List<Country> countries = mapper.selectByExample(example);
             Assert.assertEquals(2, countries.size());
 
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    /*
+    *  @description: 测试order by
+    *  orderBy()默认为Asc（升序），与orderByAsc()一样
+    * */
+    @Test
+    public void testOrderBy() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .where(Sqls.custom().andBetween("id", 50, 55))
+                    .orderBy("id").orderByAsc("countryname").orderByDesc("countrycode")
+                    .build();
+            List<Country> countries = mapper.selectByExample(example);
+            for (Country country :countries) {
+                System.out.println(country.getId() + " " + country.getCountryname() + " " + country.getCountrycode());
+            }
+            Assert.assertEquals(6, countries.size());
         } finally {
             sqlSession.close();
         }

--- a/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -27,11 +27,35 @@ public class TestExampleBuilder {
             Example example = Example.builder(Country.class).build();
             List<Country> countries = mapper.selectByExample(example);
             Assert.assertEquals(183, countries.size());
+
+            // 下面的查询会有缓存
+            Example example0 = Example.builder(Country.class)
+                    .select().build();
+            List<Country> countries0 = mapper.selectByExample(example0);
+            Assert.assertEquals(183, countries0.size());
         } finally {
             sqlSession.close();
         }
     }
 
+    @Test
+    public void testDistinct() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = Example.builder(Country.class)
+                    .distinct().build();
+            List<Country> countries = mapper.selectByExample(example);
+            Assert.assertEquals(183, countries.size());
+
+            Example example0 = Example.builder(Country.class)
+                    .selectDistinct("countryname").build();
+            List<Country> countries0 = mapper.selectByExample(example0);
+            Assert.assertEquals(183, countries0.size());
+        } finally {
+            sqlSession.close();
+        }
+    }
 
     @Test
     public void testEqualTo() {

--- a/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -145,21 +145,22 @@ public class TestExampleBuilder {
     }
     /*
     * @description: 单个where组合查询测试
+    * 直接把example的构造放到selectByExample()函数里
     * */
     @Test
     public void testWhereCompound0() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            Example example = Example.builder(Country.class)
+            List<Country> countries = mapper.selectByExample(
+                    Example.builder(Country.class)
                     .where(Sqls.custom()
                             .andEqualTo("countryname", "China")
                             .andEqualTo("id", 35)
                             .orIn("id", new ArrayList<Integer>(Arrays.asList(35, 183)))
                             .orLike("countryname","Ye%")
                     )
-                    .build();
-            List<Country> countries = mapper.selectByExample(example);
+                    .build());
             Country country35 = countries.get(2);
             Assert.assertEquals(Integer.valueOf(35), country35.getId());
             Assert.assertEquals("China", country35.getCountryname());


### PR DESCRIPTION
**Motivation**:
当前，Example对象的构建方式容易引发错误的使用，如#154；
以及，Example需要分开设置and或or条件语句，不够便捷：
```
Example example = new Example(Country.class);
example.createCriteria().andGreaterThan("id", 100).andLessThan("id", 151);
example.or().andLessThan("id", 41);
```

**Modification**:
使用builder模式来构造Example，在Example对象中添加内部静态对象Builder；
用多个where()/andWhere()/orWhere()的链式调用来避免example分开设置and/or；
用Sqls构造组合逻辑查询语句，并作为where()的参数；
添加单元测试；

**Result**:

- before
  构造Example对象
```
   Example example = new Example(Country.class);
   example.createCriteria().andGreaterThan("id", 100).andLessThan("id",151);
   example.or().andLessThan("id", 41);
```

- after
   用builder构造Example对象

   ```
   Example example = Example.builder(Country.class)
                .where(Sqls.custom().andGreaterThan("id", 100).andLessThan("id", 151))
                .orWhere(Sqls.custom().andLessThan("id", 41))
                .build();
   ```

  一个更完整的例子
```
Example example = Example.builder(Country.class)
                    .select("countryname")
                    .from("country")
                    .where(Sqls.custom()
                        .andEqualTo("countryname", "China")
                        .andEqualTo("id", 35)
                    )
                    .orWhere(Sqls.custom()
                        .andBetween("countryname", 'C', 'H')
                        .andNotLike("countryname", "Co%")
                    )
                    .andWhere(Sqls.custom()
                        .andLessThan("id", "100")
                        .orGreaterThan("id", "55")
                    )
                    .orWhere(Sqls.custom()
                        .andEqualTo("countryname", "Cook Is.")
                    )
                    .orderByAsc("id", "countryname")
                    .orderByDesc("countrycode")
                    .forUpdate()
                    .build();
```