### PR TITLE
添加别名

### DIFF
--- a/core/src/main/java/tk/mybatis/mapper/entity/EntityTable.java
+++ b/core/src/main/java/tk/mybatis/mapper/entity/EntityTable.java
@@ -90,7 +90,7 @@ public class EntityTable {
             if(matcher.find()){
                 column = matcher.group(1);
             }
-            ResultMapping.Builder builder = new ResultMapping.Builder(configuration, entityColumn.getProperty(), column, entityColumn.getJavaType());
+            ResultMapping.Builder builder = new ResultMapping.Builder(configuration, entityColumn.getProperty(), entityColumn.getProperty(), entityColumn.getJavaType());
             if (entityColumn.getJdbcType() != null) {
                 builder.jdbcType(entityColumn.getJdbcType());
             }

--- a/core/src/main/java/tk/mybatis/mapper/entity/Example.java
+++ b/core/src/main/java/tk/mybatis/mapper/entity/Example.java
@@ -168,7 +168,7 @@ public class Example implements IDynamicTableName {
             }
             for (String property : properties) {
                 if (propertyMap.containsKey(property)) {
-                    this.selectColumns.add(propertyMap.get(property).getColumn());
+                    this.selectColumns.add(propertyMap.get(property).getColumn() + " AS " + propertyMap.get(property).getProperty());
                 } else {
                     throw new MapperException("类 " + entityClass.getSimpleName() + " 不包含属性 \'" + property + "\'，或该属性被@Transient注释！");
                 }
@@ -1098,7 +1098,7 @@ public class Example implements IDynamicTableName {
             selectColumns = new LinkedHashSet<String>(entityColumns.size() - excludeColumns.size());
             for (EntityColumn column : entityColumns) {
                 if (!excludeColumns.contains(column.getColumn())) {
-                    selectColumns.add(column.getColumn());
+                    selectColumns.add(column.getColumn() + " AS " +column.getProperty());
                 }
             }
         }

--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
@@ -244,7 +244,7 @@ public class SqlHelper {
         Set<EntityColumn> columnSet = EntityHelper.getColumns(entityClass);
         StringBuilder sql = new StringBuilder();
         for (EntityColumn entityColumn : columnSet) {
-            sql.append(entityColumn.getColumn()).append(",");
+            sql.append(entityColumn.getColumn()).append(" AS ").append(entityColumn.getProperty()).append(",");
         }
         return sql.substring(0, sql.length() - 1);
     }


### PR DESCRIPTION
在@Column的字段名含名表别名的时候，会出现检索不到值的问题。
经过调查原因是SQL的返回字段名和ResultMap中的字段名不匹配造成的。
SQL的返回字段名只含有字段名（不含名表别名），ResultMap中的字段名是和@Column的name属性一致的（含名表别名）。

出现问题的代码如下：
我的代码是通过在表名中加入Left Join以实现简单的多表关联查询。但是就算没有多表查询，@Column中指定表别名的时候依旧会有问题的。

`@Table(name = 
             "ATABLE AS A " + 
             "LEFT JOIN BTABLE AS B ON A.id = B.id "
)
public class AlipayComposite {

    @Id
    @Column(name = "A.field1")
    private Long atableField1;

    @Column(name = "BTable.field1")
    private String btableField1;

    // ....Get/Set略	
}`