### PR TITLE
当某个column为主键或updatable=false时则忽略其参与SQL拼装.

### DIFF
--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
@@ -460,24 +460,24 @@ public class SqlHelper {
                 }
                 versionColumn = column;
             }
-            if (!column.isId() && column.isUpdatable()) {
-                if (column == versionColumn) {
-                    Version version = versionColumn.getEntityField().getAnnotation(Version.class);
-                    String versionClass = version.nextVersion().getCanonicalName();
-                    //version = ${@tk.mybatis.mapper.version@nextVersionClass("versionClass", version)}
-                    sql.append(column.getColumn())
-                            .append(" = ${@tk.mybatis.mapper.version.VersionUtil@nextVersion(")
-                            .append("@").append(versionClass).append("@class, ")
-                            .append(column.getProperty()).append(")},");
-                } else if (notNull) {
-                    sql.append(SqlHelper.getIfNotNull(entityName, column, column.getColumnEqualsHolder(entityName) + ",", notEmpty));
-                } else {
-                    sql.append(column.getColumnEqualsHolder(entityName) + ",");
-                }
-            } else if(column.isId() && column.isUpdatable()){
-                //set id = id,
-                sql.append(column.getColumn()).append(" = ").append(column.getColumn()).append(",");
-            }
+			if (column.isId()) {
+				continue;
+			}
+			if (column.isUpdatable()) {
+				if (column == versionColumn) {
+					Version version = versionColumn.getEntityField().getAnnotation(Version.class);
+					String versionClass = version.nextVersion().getCanonicalName();
+					//version = ${@tk.mybatis.mapper.version@nextVersionClass("versionClass", version)}
+					sql.append(column.getColumn()).append(" = ${@tk.mybatis.mapper.version.VersionUtil@nextVersion(")
+							.append("@").append(versionClass).append("@class, ").append(column.getProperty())
+							.append(")},");
+				} else if (notNull) {
+					sql.append(SqlHelper.getIfNotNull(entityName, column, column.getColumnEqualsHolder(entityName) + ",",
+							notEmpty));
+				} else {
+					sql.append(column.getColumnEqualsHolder(entityName)).append(",");
+				}
+			}
         }
         sql.append("</set>");
         return sql.toString();


### PR DESCRIPTION
修改tk.mybatis.mapper.mapperhelper.SqlHelper.updateSetColumns方法，使其在model字段标识为@Id或@Colum(updatable=false)时忽略该字段参与SQL拼装。

剔除了"SET ID=ID"的逻辑，因为在接入Microsoft SQLServer数据源时，该语法不受支持([Err] 42000 - [SQL Server]无法更新标识列 'ID')。