### PR TITLE
在生成的model中，增加字段名的常量，便于使用Example拼接查询条件的时候使用。

### DIFF
--- a/generator/src/main/java/tk/mybatis/mapper/generator/MapperPlugin.java
+++ b/generator/src/main/java/tk/mybatis/mapper/generator/MapperPlugin.java
@@ -54,6 +54,8 @@ public class MapperPlugin extends FalseMethodPlugin {
     private CommentGeneratorConfiguration commentCfg;
     //强制生成注解
     private boolean                       forceAnnotation;
+    //是否生成字段名常量
+    private boolean generateColumnConsts = false;
 
     public String getDelimiterName(String name) {
         StringBuilder nameBuilder = new StringBuilder();
@@ -205,7 +207,6 @@ public class MapperPlugin extends FalseMethodPlugin {
             if (useMapperCommentGenerator) {
                 commentCfg.addProperty("forceAnnotation", forceAnnotation);
             }
-            this.forceAnnotation = forceAnnotation.equalsIgnoreCase("TRUE");
         }
         String beginningDelimiter = this.properties.getProperty("beginningDelimiter");
         if (StringUtility.stringHasValue(beginningDelimiter)) {
@@ -223,5 +224,10 @@ public class MapperPlugin extends FalseMethodPlugin {
             commentCfg.addProperty("beginningDelimiter", this.beginningDelimiter);
             commentCfg.addProperty("endingDelimiter", this.endingDelimiter);
         }
+        String generateColumnConsts = this.properties.getProperty("generateColumnConsts");
+        if (StringUtility.stringHasValue(generateColumnConsts)) {
+            this.generateColumnConsts = generateColumnConsts.equalsIgnoreCase("TRUE");
+        }
+
     }
 }

--- a/generator/src/main/java/tk/mybatis/mapper/generator/MapperPlugin.java
+++ b/generator/src/main/java/tk/mybatis/mapper/generator/MapperPlugin.java
@@ -24,10 +24,9 @@
 
 package tk.mybatis.mapper.generator;
 
+import org.mybatis.generator.api.IntrospectedColumn;
 import org.mybatis.generator.api.IntrospectedTable;
-import org.mybatis.generator.api.dom.java.FullyQualifiedJavaType;
-import org.mybatis.generator.api.dom.java.Interface;
-import org.mybatis.generator.api.dom.java.TopLevelClass;
+import org.mybatis.generator.api.dom.java.*;
 import org.mybatis.generator.config.CommentGeneratorConfiguration;
 import org.mybatis.generator.config.Context;
 import org.mybatis.generator.internal.util.StringUtility;
@@ -117,6 +116,18 @@ public class MapperPlugin extends FalseMethodPlugin {
             topLevelClass.addAnnotation("@Table(name = \"" + getDelimiterName(tableName) + "\")");
         } else if (forceAnnotation) {
             topLevelClass.addAnnotation("@Table(name = \"" + getDelimiterName(tableName) + "\")");
+        }
+
+        for (IntrospectedColumn introspectedColumn : introspectedTable.getAllColumns()) {
+            Field field = new Field();
+            field.setVisibility(JavaVisibility.PUBLIC);
+            field.setStatic(true);
+            field.setFinal(true);
+            field.setName(introspectedColumn.getActualColumnName().toUpperCase()); //$NON-NLS-1$
+            field.setType(new FullyQualifiedJavaType(String.class.getName())); //$NON-NLS-1$
+            field.setInitializationString("\""+ introspectedColumn.getJavaProperty()+"\"");
+            context.getCommentGenerator().addClassComment(topLevelClass, introspectedTable);
+            topLevelClass.addField(field);
         }
     }
 


### PR DESCRIPTION
如题。
生成的代码如下：
```
@Table(name = "ec_auth_resource")
public class EcAuthResource {
……
    public static final String CREATE_TIME = "create_time";
    public static final String CREATE_USER_ID = "create_user_id";
    public static final String CREATE_USER_NAME = "create_user_name";
    public static final String UPDATE_TIME = "update_time";
    public static final String UPDATE_USER_ID = "update_user_id";
    public static final String UPDATE_USER_NAME = "update_user_name";
```
这样可以直接使用常量拼接条件
```
        if (StringUtils.isNotBlank(ecAuthResource.getCreateUserName()))
            criteria.andLike(EcAuthResource.CREATE_USER_NAME,ecAuthResource.getCreateUserName()+ "%");
```