### PR TITLE
修改了SelectByPrimaryKeyMapper的注释

### DIFF
--- a/base/src/main/java/tk/mybatis/mapper/common/base/select/SelectByPrimaryKeyMapper.java
+++ b/base/src/main/java/tk/mybatis/mapper/common/base/select/SelectByPrimaryKeyMapper.java
@@ -30,6 +30,8 @@ import tk.mybatis.mapper.provider.base.BaseSelectProvider;
 
 /**
  * 通用Mapper接口,其他接口继承该接口即可
+ * 需要在Entity类中为主键字段加上@javax.persistence.Id注解,声明主键
+ * 否则无法确认实体类哪个属性是主键
  * <p/>
  * <p>这是一个例子，自己扩展时可以参考</p>
  * <p/>


### PR DESCRIPTION
这个地方如果不为Entity的主键字段加上注解很容易出现错误，tkMapper无法识别哪个字段是主键，用Entity中的每个字段都去匹配。