### PR TITLE
处理#637的问题,根据注释理解,新版本默认是启用简单类型的,因此if判断需要跟默认为false的时候做!处理

### DIFF
--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/resolve/DefaultEntityResolve.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/resolve/DefaultEntityResolve.java
@@ -75,7 +75,7 @@ public class DefaultEntityResolve implements EntityResolve {
             //如果启用了简单类型，就做简单类型校验，如果不是简单类型，直接跳过
             //3.5.0 如果启用了枚举作为简单类型，就不会自动忽略枚举类型
             //4.0 如果标记了 Column 或 ColumnType 注解，也不忽略
-            if (config.isUseSimpleType()
+            if (!config.isUseSimpleType()
                     && !field.isAnnotationPresent(Column.class)
                     && !field.isAnnotationPresent(ColumnType.class)
                     && !(SimpleTypeUtil.isSimpleType(field.getJavaType())


### PR DESCRIPTION
处理#637中DefaultEntityResolve对于基本类型的判断会因为默认配置而直接跳过的情况,个人理解是对isUseSimpleType取否,后面的逻辑判断并不是很理解,所以希望@abel533大神看情况采纳,谢谢!