### PR TITLE
Sorting fields for deterministic order

### DIFF
--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/FieldHelper.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/FieldHelper.java
@@ -172,6 +172,12 @@ public class FieldHelper {
                 return fieldList;
             }
             Field[] fields = entityClass.getDeclaredFields();
+            Arrays.sort(fields, new Comparator<Object>() {
+                @Override
+                public int compare(Object a, Object b) {
+                    return a.toString().compareTo(b.toString());
+                }
+            });
             int index = 0;
             for (int i = 0; i < fields.length; i++) {
                 Field field = fields[i];

--- a/core/src/test/java/tk/mybatis/mapper/mapperhelper/SqlHelperTest.java
+++ b/core/src/test/java/tk/mybatis/mapper/mapperhelper/SqlHelperTest.java
@@ -35,7 +35,7 @@ public class SqlHelperTest {
         Assert.assertEquals(" AND is_valid = 1", notLogicDeletedColumn);
 
         String updateSetColumns = SqlHelper.updateSetColumns(User.class, null, false, false);
-        Assert.assertEquals("<set>username = #{username},is_valid = 1,</set>", updateSetColumns);
+        Assert.assertEquals("<set>is_valid = 1,username = #{username},</set>", updateSetColumns);
     }
 
 }


### PR DESCRIPTION
API `FieldHelper.getFields` replies on Java's reflection api `getFields`. There is no guarantee in order of the returned array of fields and thus, some tests can fail due to a different order. This, at least, affect the following test cases:

https://github.com/abel533/Mapper/blob/12b682f67a960d326938e53571786840c8d0fa23/core/src/test/java/tk/mybatis/mapper/mapperhelper/FieldHelperTest.java#L22
https://github.com/abel533/Mapper/blob/5e0adfe9a2d5a36733e2556f3b014c3bd7ff653a/core/src/test/java/tk/mybatis/mapper/mapperhelper/SqlHelperTest.java#L24


This PR propose to sorts the returned field so that the order assumptions (in this PR, alphabetical order) in the test cases are correct. 

Please let me know if you want to discuss the changes more.


