### PR TITLE
修复一个错误，该错误可能导致 EntityHelper.entityTableMap 被错误清空

### DIFF
--- a/spring-boot-starter/mapper-spring-boot-autoconfigure/src/main/java/tk/mybatis/mapper/autoconfigure/MapperCacheDisabler.java
+++ b/spring-boot-starter/mapper-spring-boot-autoconfigure/src/main/java/tk/mybatis/mapper/autoconfigure/MapperCacheDisabler.java
@@ -76,7 +76,7 @@ public class MapperCacheDisabler implements InitializingBean {
                 for (Object key : new ArrayList(cache.keySet())) {
                     Class entityClass = (Class) key;
                     //清理老的ClassLoader缓存的数据，避免测试环境溢出
-                    if (!entityClass.getClassLoader().equals(classLoader)) {
+                    if (!(entityClass.getClassLoader().equals(classLoader) || entityClass.getClassLoader().equals(classLoader.getParent()))) {
                         cache.remove(entityClass);
                     }
                 }


### PR DESCRIPTION
当 Entity 被 URLClassLoader 加载时，实际上加载它的是其 parent，即 AppClassLoader，MapperCacheDisabler 在判断是否需要清空缓存数据时，应该考虑当前 Thread 的 contextClassLoader 为 URLClassLoader 时的判断逻辑。