### PR TITLE
修复 AggregationProvider 的问题

### DIFF
--- a/extra/pom.xml
+++ b/extra/pom.xml
@@ -39,6 +39,7 @@
     <properties>
         <jdk.version>1.8</jdk.version>
         <mapper-module.version>1.1.5</mapper-module.version>
+		<argLine>-Dfile.encoding=UTF-8</argLine>
     </properties>
 
     <dependencies>

--- a/extra/src/main/java/tk/mybatis/mapper/additional/aggregation/AggregationProvider.java
+++ b/extra/src/main/java/tk/mybatis/mapper/additional/aggregation/AggregationProvider.java
@@ -37,13 +37,13 @@ public class AggregationProvider extends MapperTemplate {
         if (StringUtil.isNotEmpty(condition.getAggregateAliasName())) {
             selectBuilder.append(condition.getAggregateAliasName());
         } else {
-            selectBuilder.append(wrapKeyword(wrapKeyword, columnName));
+            selectBuilder.append(wrapKeyword(wrapKeyword, condition.getAggregateProperty()));
         }
         if (condition.getGroupByProperties() != null && condition.getGroupByProperties().size() > 0) {
             for (String property : condition.getGroupByProperties()) {
                 selectBuilder.append(", ");
                 columnName = propertyMap.get(property).getColumn();
-                selectBuilder.append(columnName).append(" AS ").append(wrapKeyword(wrapKeyword, columnName));
+                selectBuilder.append(columnName).append(" AS ").append(wrapKeyword(wrapKeyword, property));
             }
         }
         return selectBuilder.toString();

--- a/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/AggregationMapperTest.java
+++ b/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/AggregationMapperTest.java
@@ -39,7 +39,7 @@ public class AggregationMapperTest extends BaseTest {
         try {
             UserMapper mapper = sqlSession.getMapper(UserMapper.class);
             AggregateCondition aggregateCondition = AggregateCondition.builder().
-                    aggregateBy("id").aliasName("total").aggregateType(AggregateType.COUNT).groupBy("role");
+                    aggregateBy("id").aliasName("total").aggregateType(AggregateType.COUNT).groupBy("roLe");
             Example example = new Example(User.class);
             List<User> m = mapper.selectAggregationByExample(example, aggregateCondition);
             Assert.assertEquals(2, m.size());
@@ -86,9 +86,9 @@ public class AggregationMapperTest extends BaseTest {
         try {
             UserMapper mapper = sqlSession.getMapper(UserMapper.class);
             AggregateCondition aggregateCondition = AggregateCondition.builder().
-                    aggregateBy("id").aliasName("aggregation").aggregateType(AggregateType.MAX).groupBy("role");
+                    aggregateBy("id").aliasName("aggregation").aggregateType(AggregateType.MAX).groupBy("roLe");
             Example example = new Example(User.class);
-            example.setOrderByClause("role desc");
+            example.setOrderByClause("ro_le desc");
             List<User> m = mapper.selectAggregationByExample(example, aggregateCondition);
             Assert.assertEquals(2, m.size());
             Assert.assertEquals(new Long(6), m.get(0).getAggregation());

--- a/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/CreateDB.sql
+++ b/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/CreateDB.sql
@@ -3,12 +3,12 @@ drop table user if exists;
 create table user (
   id          integer NOT NULL PRIMARY KEY,
   name varchar(32),
-  role VARCHAR(32)
+  ro_le VARCHAR(32)
 );
 
-INSERT INTO user (id, name, role) VALUES (1, 'Angola', 'Admin');
-INSERT INTO user (id, name, role) VALUES (2, 'Afghanistan', 'Admin');
-INSERT INTO user (id, name, role) VALUES (3, 'Albania', 'Admin');
-INSERT INTO user (id, name, role) VALUES (4, 'Algeria', 'USER');
-INSERT INTO user (id, name, role) VALUES (5, 'Andorra', 'USER');
-INSERT INTO user (id, name, role) VALUES (6, 'Anguilla', 'USER');
+INSERT INTO user (id, name, ro_le) VALUES (1, 'Angola', 'Admin');
+INSERT INTO user (id, name, ro_le) VALUES (2, 'Afghanistan', 'Admin');
+INSERT INTO user (id, name, ro_le) VALUES (3, 'Albania', 'Admin');
+INSERT INTO user (id, name, ro_le) VALUES (4, 'Algeria', 'USER');
+INSERT INTO user (id, name, ro_le) VALUES (5, 'Andorra', 'USER');
+INSERT INTO user (id, name, ro_le) VALUES (6, 'Anguilla', 'USER');

--- a/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/User.java
+++ b/extra/src/test/java/tk/mybatis/mapper/additional/aggregation/User.java
@@ -36,7 +36,7 @@ public class User implements Serializable {
     @Id
     private Long              id;
     private String            name;
-    private String            role;
+    private String            roLe;
     //存储聚合函数值
     @Transient
     private Long aggregation;
@@ -57,12 +57,12 @@ public class User implements Serializable {
         this.name = name;
     }
 
-    public String getRole() {
-        return role;
+    public String getRoLe() {
+        return roLe;
     }
 
-    public void setRole(String role) {
-        this.role = role;
+    public void setRoLe(String roLe) {
+        this.roLe = roLe;
     }
 
     public Long getAggregation() {


### PR DESCRIPTION
在列名与entity属性不同名的情况下，AggregationMapper.selectAggregationByExample 返回的 List 对象不正确。