### PR TITLE
对齐依赖版本 align mybatis-spring to 1.3.2 in all modules

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <spring.version>4.3.8.RELEASE</spring.version>
-        <mybatis-spring.version>1.3.1</mybatis-spring.version>
+        <mybatis-spring.version>1.3.2</mybatis-spring.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
对齐依赖版本，以免存在API行为不一致。