### PR TITLE
Fixed flaky tests in `tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey`

### DIFF
--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.sql.Connection;
@@ -45,8 +46,9 @@ import java.util.Map;
  * @author liuzh
  */
 public class TestDeleteByPrimaryKey {
-	@Before
-	public void setupDB() {
+
+    @Before
+    public void setupDB() {
         SqlSession sqlSession = MybatisHelper.getSqlSession();
         try {
             Connection conn = sqlSession.getConnection();
@@ -55,11 +57,11 @@ public class TestDeleteByPrimaryKey {
             runner.setLogWriter(null);
             runner.runScript(reader);
             reader.close();
-        } catch (IOException e) {} 
+        } catch (IOException e) {}
         finally {
             sqlSession.close();
         }
-	}
+    }
 	
     /**
      * 主要测试删除

--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestDeleteByPrimaryKey.java
@@ -24,13 +24,18 @@
 
 package tk.mybatis.mapper.test.country;
 
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
-
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,7 +45,22 @@ import java.util.Map;
  * @author liuzh
  */
 public class TestDeleteByPrimaryKey {
-
+	@Before
+	public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {} 
+        finally {
+            sqlSession.close();
+        }
+	}
+	
     /**
      * 主要测试删除
      */


### PR DESCRIPTION
### Description 
The tests in the test class `tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey` could fail if the test database is polluted by some other tests.

### Steps to reproduce
Run the tests `tk.mybatis.mapper.test.ids.TestIds.testSelectByIds`, `tk.mybatis.mapper.base.genid.InsertGenIdTest.testGenId`, and `tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey.testDynamicDeleteEntity` in exactly this order in a shared JVM.

### Expected Behaviour
All tests should pass

### Actual Behaviour
The first and the second tests pass but the third test fails

### Findings
The test `tk.mybatis.mapper.test.country.TestDeleteByPrimaryKey.testDynamicDeleteEntity` was failing because the data in the test database gets changed by the first two tests. The database is set up by a static block in `MybatisHelper` when the first test is executed. The second test makes some changes in the data (or in this case pollutes the data). And when the third test is run, the test fails.

Unlike the first and the third tests, the second test does not use `MybatisHelper` to get the SQL session, so it can change the schema of the database. However, the third test can not reset it as the operation of setting up the database is in the static block which is executed only when the class is referenced for the first time.

If we reset the test database before executing the third test, all three tests pass no matter in which order we run it. So, adding a `@Before` method to perform "database reset" operation seems to be a reasonable solution. Another way to solve it would be to do this task in the `@After` method of the second test. Please let me know if you want to discuss the changes more.
