### PR TITLE
修复了`Class.getDeclaredFields()`返回的元素的不确定顺序引起的问题

### DIFF
--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/FieldHelper.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/FieldHelper.java
@@ -181,6 +181,7 @@ public class FieldHelper {
                 return fieldList;
             }
             Field[] fields = entityClass.getDeclaredFields();
+            Arrays.sort(fields, Comparator.comparing(Field::getName));
             int index = 0;
             for (int i = 0; i < fields.length; i++) {
                 Field field = fields[i];

--- a/core/src/test/java/tk/mybatis/mapper/mapperhelper/ComplexEntityTest.java
+++ b/core/src/test/java/tk/mybatis/mapper/mapperhelper/ComplexEntityTest.java
@@ -152,19 +152,19 @@ public class ComplexEntityTest {
         sqlBuilder.append(SqlHelper.fromTable(entityClass, entityTable.getName()));
         sqlBuilder.append(SqlHelper.whereAllIfColumns(entityClass, config.isNotEmpty()));
         final String sql = sqlBuilder.toString();
-        Assert.assertEquals("SELECT id,user_name,address,state  FROM user " +
+        Assert.assertEquals("SELECT address,id,state,user_name  FROM user " +
                 "<where>" +
-                "<if test=\"id != null\"> AND id = #{id}</if>" +
-                "<if test=\"userName != null\"> AND user_name = #{userName}</if>" +
                 "<if test=\"address != null\"> AND address = #{address, typeHandler=tk.mybatis.mapper.mapperhelper.ComplexEntityTest$AddressHandler}</if>" +
-                "<if test=\"state != null\"> AND state = #{state}</if></where>", sql);
+                "<if test=\"id != null\"> AND id = #{id}</if>" +
+                "<if test=\"state != null\"> AND state = #{state}</if>" +
+                "<if test=\"userName != null\"> AND user_name = #{userName}</if></where>", sql);
 
         final ResultMap resultMap = entityTable.getResultMap(configuration);
         final List<ResultMapping> resultMappings = resultMap.getResultMappings();
-        final ResultMapping idMapping = resultMappings.get(0);
-        final ResultMapping userNameMapping = resultMappings.get(1);
-        final ResultMapping addressMapping = resultMappings.get(2);
-        final ResultMapping stateMapping = resultMappings.get(3);
+        final ResultMapping addressMapping = resultMappings.get(0);
+        final ResultMapping idMapping = resultMappings.get(1);
+        final ResultMapping stateMapping = resultMappings.get(2);
+        final ResultMapping userNameMapping = resultMappings.get(3);
 
         Assert.assertEquals("id", idMapping.getColumn());
         Assert.assertEquals("id", idMapping.getProperty());

--- a/core/src/test/java/tk/mybatis/mapper/mapperhelper/SqlHelperTest.java
+++ b/core/src/test/java/tk/mybatis/mapper/mapperhelper/SqlHelperTest.java
@@ -35,7 +35,7 @@ public class SqlHelperTest {
         Assert.assertEquals(" AND is_valid = 1", notLogicDeletedColumn);
 
         String updateSetColumns = SqlHelper.updateSetColumns(User.class, null, false, false);
-        Assert.assertEquals("<set>username = #{username},is_valid = 1,</set>", updateSetColumns);
+        Assert.assertEquals("<set>is_valid = 1,username = #{username},</set>", updateSetColumns);
     }
 
 }


### PR DESCRIPTION
- `FieldHelper`使用Java反射`Class.getDeclaredFields()`来获取特定类的字段信息
https://github.com/abel533/Mapper/blob/5e31029b2df157afe9031fe183f6d7795ac2aa19/core/src/main/java/tk/mybatis/mapper/mapperhelper/FieldHelper.java#L183

- 然而，官方的Javadoc提到，随着时间的推移，元素的顺序不会保持
- 修复程序已于2022年10月15日在[此提交]（https://github.com/abel533/Mapper/pull/666/commits/70232e7c5edd63bee897873bde25efbb2d076a1a）中被合并，但在[此提交]（https://github.com/abel533/Mapper/commit/79d313a7ca6cba6c5d5323746fb83ed5744180a1）中删除
- 我怀疑这是因为2022年10月16日测试“ComplexEntityTest.test()”中的[此更改]（https://github.com/abel533/Mapper/commit/2fcefe65e77db1e57edb33290cd0e347ecaec8），该测试会因订购问题而失败。
- 由于字段已经排序，这个测试的预期值应该从
```
Assert.assertEquals("SELECT id,user_name,address,state  FROM user " +
       "<where>" +
       "<if test=\"id != null\"> AND id = #{id}</if>" +
       "<if test=\"userName != null\"> AND user_name = #{userName}</if>" +
       "<if test=\"address != null\"> AND address = #{address, typeHandler=tk.mybatis.mapper.mapperhelper.ComplexEntityTest$AddressHandler}</if>" +
       "<if test=\"state != null\"> AND state = #{state}</if></where>", sql);
```
去
```
Assert.assertEquals("SELECT address,id,state,user_name  FROM user " +
        "<where>" +
        "<if test=\"address != null\"> AND address = #{address, typeHandler=tk.mybatis.mapper.mapperhelper.ComplexEntityTest$AddressHandler}</if>" +
        "<if test=\"id != null\"> AND id = #{id}</if>" +
         "<if test=\"state != null\"> AND state = #{state}</if>" +
         "<if test=\"userName != null\"> AND user_name = #{userName}</if></where>", sql);
```
- 上述更改将修复问题，以及由“Class.getDeclaredFields()”引起的问题。
- 如果不排序`Class.getDeclaredFields()`，我们在运行[NonDex]（https://github.com/TestingResearchIllinois/NonDex）时可能会观察到以下错误
- 这个“公关”修复了上述问题 - https://github.com/abel533/Mapper/issues/895