### PR TITLE
fix: 限制流水线权限

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Publish package to the Maven Central Repository
 on:
   push:
     tags: [ "*" ]
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     types: [ opened, reopened, edited ]
   push:
     branches: [ develop, master ]
+permissions:
+  contents: read
+
 jobs:
   mvn_verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi! 这个 PR 在流水线上限制了权限，参考 [GitHub 官方](https://docs.github.com/en/actions/reference/security/secure-use#use-secrets-for-sensitive-information) 给出的最佳安全实践建议。