### PR TITLE
Fixed the non-deterministic behavior of tests in TkMapperServiceTest

### DIFF
--- a/solon-plugin/src/test/java/tk/mybatis/solon/test/service/TkMapperServiceTest.java
+++ b/solon-plugin/src/test/java/tk/mybatis/solon/test/service/TkMapperServiceTest.java
@@ -32,7 +32,7 @@ public class TkMapperServiceTest {
     private UserMapper userMapper;
 
     @Test
-    public void all() {
+    public final void all() {
 
         userMapper.selectAll().forEach(u -> log.info(u.toString()));
     }
@@ -41,7 +41,7 @@ public class TkMapperServiceTest {
      * 根据主键查询
      */
     @Test
-    public void byId() {
+    public final void byId() {
 
         User user = userMapper.selectByPrimaryKey(1);
         log.info(user == null ? null : user.toString());
@@ -51,7 +51,7 @@ public class TkMapperServiceTest {
      * 根据example查询
      */
     @Test
-    public void exampleQuery() {
+    public final void exampleQuery() {
         Example example = new Example(User.class);
         example.and().andLike("name", "%张%");
         userMapper.selectByExample(example).forEach(u -> log.info(u.toString()));
@@ -61,7 +61,7 @@ public class TkMapperServiceTest {
      * mybatis 原生查询
      */
     @Test
-    public void rawMybatisQuery() {
+    public final void rawMybatisQuery() {
 
         userMapper.findByGTAge(11).forEach(u -> log.info(u.toString()));
     }
@@ -71,7 +71,7 @@ public class TkMapperServiceTest {
      */
     @Test
     @Rollback
-    public void logicDelInsert() {
+    public final void logicDelInsert() {
 
         List<User> users = userMapper.findByName("张麻子");
         if (!users.isEmpty()) {


### PR DESCRIPTION
## Problem
When the test execution order is changed, all five tests in file `TkMapperServiceTest.java` would show a non-deterministic behavior and output the following errors of two kinds:
- `IllegalArgumentException: wrong number of arguments`
- `IllegalMonitorStateException: current thread is not owner`

The root cause of these errors is that Salon generates a subclass proxy for the test class. When the test methods are non-final, the proxy would override them and route calls through Solon's AOP chain. With NonDex randomizing the iteration order, this proxy path intermittently mis-invokes methods and the above errors would be generated.

Commands to reproduce the errors:
```
mvn -pl solon-plugin -Dcheckstyle.skip=true -Drat.skip=true \
    edu.illinois:nondex-maven-plugin:2.1.7:nondex \
    -Dtest=tk.mybatis.solon.test.service.TkMapperServiceTest#testName \ -- replace with the actual test name
    -DnondexRuns=10 |& tee nondex-$(date +%s).log
```

## Proposed Fix
The code changes are local and minimum. By changing the test method to final, we can avoid Solon overriding or intercepting them.

**Involved Tests**
- `TkMapperServiceTest.all`
- `TkMapperServiceTest.byId`
- `TkMapperServiceTest.exampleQuery`
- `TkMapperServiceTest.rawMybatisQuery`
- `TkMapperServiceTest.logicDelInsert`
