### PR TITLE
Reset the polluted database to ensure some tests work as expected

### DIFF
--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestExistsWithPrimaryKey.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestExistsWithPrimaryKey.java
@@ -24,12 +24,18 @@
 
 package tk.mybatis.mapper.test.country;
 
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 
 /**
  * 通过主键查询
@@ -37,6 +43,22 @@ import tk.mybatis.mapper.model.Country;
  * @author liuzh
  */
 public class TestExistsWithPrimaryKey {
+
+    @Before
+    public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {}
+        finally {
+            sqlSession.close();
+        }
+    }
 
     /**
      * 根据PK进行查询

--- a/base/src/test/java/tk/mybatis/mapper/test/country/TestInsert.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/country/TestInsert.java
@@ -25,13 +25,19 @@
 package tk.mybatis.mapper.test.country;
 
 import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import tk.mybatis.mapper.mapper.CountryMapper;
 import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 import java.util.List;
 
 /**
@@ -40,6 +46,22 @@ import java.util.List;
  * @author liuzh
  */
 public class TestInsert {
+
+    @Before
+    public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {}
+        finally {
+            sqlSession.close();
+        }
+    }
 
     /**
      * 插入空数据,id不能为null,会报错

--- a/base/src/test/java/tk/mybatis/mapper/test/example/TestSelectByExample.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/example/TestSelectByExample.java
@@ -24,8 +24,11 @@
 
 package tk.mybatis.mapper.test.example;
 
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -37,6 +40,9 @@ import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
 import tk.mybatis.mapper.model.Country2;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -48,6 +54,22 @@ import java.util.Set;
 public class TestSelectByExample {
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {}
+        finally {
+            sqlSession.close();
+        }
+    }
 
     @Test
     public void testSelectByExample() {


### PR DESCRIPTION
## Problem 
When the execution order of tests are shuffled, if tests (polluters) that make modifications on the database run before tests (victims) that rely on the original/unmodified database, the database will be polluted and victim tests will fail with assertionError.

**Involved tests:**
```
tk.mybatis.mapper.test.country.TestExistsWithPrimaryKey.testDynamicExistsWithPrimaryKey
tk.mybatis.mapper.test.country.TestInsert.testDynamicInsert
tk.mybatis.mapper.test.example.TestSelectByExample.testAndExample
tk.mybatis.mapper.test.example.TestSelectByExample.testAndOr
tk.mybatis.mapper.test.example.TestSelectByExample.testExcludeColumnsByExample
tk.mybatis.mapper.test.example.TestSelectByExample.testOrderBy
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExample
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExample2
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExample3
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExample4
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExampleForUpdate
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExampleInNotIn
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectByExampleInNotIn2
tk.mybatis.mapper.test.example.TestSelectByExample.testSelectPropertisCheckCorrect
```
The above are all order-dependent victim tests and they test the properties of database without modification. 

Take `TestExistsWithPrimaryKey.testDynamicExistsWithPrimaryKey` as an example:
```
Country country = new Country();
country.setId(35);
Assert.assertEquals(true, mapper.existsWithPrimaryKey(country));

country.setId(0);
Assert.assertEquals(false, mapper.existsWithPrimaryKey(country));
```
It expects `country` with `id=35` exists in the database but it actually fails with assertionError if polluter tests that delete/modify the `country` with `id=35` in the database run before it.

## Proposed Fix
A simple and safe way to ensure victim tests can work as we expect is to reset/clean the database before executing such tests. 

Glad to discuss this issue if you have concerns.
