### PR TITLE
Reset database before executing TestExampleBuilder class

### DIFF
--- a/base/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
+++ b/base/src/test/java/tk/mybatis/mapper/test/example/TestExampleBuilder.java
@@ -1,7 +1,10 @@
 package tk.mybatis.mapper.test.example;
 
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import tk.mybatis.mapper.entity.Example;
 import tk.mybatis.mapper.mapper.CountryMapper;
@@ -9,6 +12,9 @@ import tk.mybatis.mapper.mapper.MybatisHelper;
 import tk.mybatis.mapper.model.Country;
 import tk.mybatis.mapper.util.Sqls;
 
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,6 +24,22 @@ import java.util.List;
  * @date 2017/11/18
  */
 public class TestExampleBuilder {
+
+    @Before
+    public void setupDB() {
+        SqlSession sqlSession = MybatisHelper.getSqlSession();
+        try {
+            Connection conn = sqlSession.getConnection();
+            Reader reader = Resources.getResourceAsReader("CreateDB.sql");
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.runScript(reader);
+            reader.close();
+        } catch (IOException e) {}
+        finally {
+            sqlSession.close();
+        }
+    }
 
     @Test
     public void testExampleBuilder() {


### PR DESCRIPTION
## Problem
The following tests in `TestExampleBuilder.java` are detected to be order-dependent and they may fail when the execution order of tests (in `base` module) is shuffled.
```
tk.mybatis.mapper.test.example.TestExampleBuilder.testBetween
tk.mybatis.mapper.test.example.TestExampleBuilder.testDistinct
tk.mybatis.mapper.test.example.TestExampleBuilder.testEqualTo
tk.mybatis.mapper.test.example.TestExampleBuilder.testExampleBuilder
tk.mybatis.mapper.test.example.TestExampleBuilder.testForUpdate
tk.mybatis.mapper.test.example.TestExampleBuilder.testIn
tk.mybatis.mapper.test.example.TestExampleBuilder.testMultiWhereCompound
tk.mybatis.mapper.test.example.TestExampleBuilder.testOrderBy
tk.mybatis.mapper.test.example.TestExampleBuilder.testWhereCompound0
tk.mybatis.mapper.test.example.TestExampleBuilder.testWhereCompound1
tk.mybatis.mapper.test.example.TestExampleBuilder.testWhereOrWhereCompound
```
Similar to the problem raised in https://github.com/abel533/Mapper/pull/941, the above tests rely on a database that is original/unmodified. When some test runs before them and modifies some shared values in the database, these tests would fail because the database is polluted and properties of the database have changed.

## Proposed Fix
Fix for these tests is the same as the mentioned PR. Resetting/Cleaning the database before executing tests in  `TestExampleBuilder` enables the tests to access a database with unchanged properties. With this fix, these tests should pass whatever the execution order is.

(Detection tool is iDFlakies, please refer to https://github.com/UT-SE-Research/iDFlakies)
