### PR TITLE
Add safe condition checks

### DIFF
--- a/base/src/main/java/tk/mybatis/mapper/provider/ExampleProvider.java
+++ b/base/src/main/java/tk/mybatis/mapper/provider/ExampleProvider.java
@@ -54,6 +54,9 @@ public class ExampleProvider extends MapperTemplate {
         if (isCheckExampleEntityClass()) {
             sql.append(SqlHelper.exampleCheck(entityClass));
         }
+        if (getConfig().isSafeSelect()) {
+            sql.append(SqlHelper.exampleHasAtLeastOneCriteriaCheck("_parameter"));
+        }
         sql.append(SqlHelper.exampleCountColumn(entityClass));
         sql.append(SqlHelper.fromTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.exampleWhereClause());
@@ -104,6 +107,9 @@ public class ExampleProvider extends MapperTemplate {
         StringBuilder sql = new StringBuilder("SELECT ");
         if (isCheckExampleEntityClass()) {
             sql.append(SqlHelper.exampleCheck(entityClass));
+        }
+        if (getConfig().isSafeSelect()) {
+            sql.append(SqlHelper.exampleHasAtLeastOneCriteriaCheck("_parameter"));
         }
         sql.append("<if test=\"distinct\">distinct</if>");
         //支持查询指定列

--- a/base/src/main/java/tk/mybatis/mapper/provider/base/BaseDeleteProvider.java
+++ b/base/src/main/java/tk/mybatis/mapper/provider/base/BaseDeleteProvider.java
@@ -54,7 +54,7 @@ public class BaseDeleteProvider extends MapperTemplate {
         StringBuilder sql = new StringBuilder();
         //如果设置了安全删除，就不允许执行不带查询条件的 delete 方法
         if (getConfig().isSafeDelete()) {
-            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getColumns(entityClass)));
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getColumns(entityClass), isNotEmpty()));
         }
         // 如果是逻辑删除，则修改为更新表，修改逻辑删除字段的值
         if (SqlHelper.hasLogicDeleteColumn(entityClass)) {

--- a/base/src/main/java/tk/mybatis/mapper/provider/base/BaseSelectProvider.java
+++ b/base/src/main/java/tk/mybatis/mapper/provider/base/BaseSelectProvider.java
@@ -25,6 +25,7 @@
 package tk.mybatis.mapper.provider.base;
 
 import org.apache.ibatis.mapping.MappedStatement;
+import tk.mybatis.mapper.mapperhelper.EntityHelper;
 import tk.mybatis.mapper.mapperhelper.MapperHelper;
 import tk.mybatis.mapper.mapperhelper.MapperTemplate;
 import tk.mybatis.mapper.mapperhelper.SqlHelper;
@@ -51,6 +52,9 @@ public class BaseSelectProvider extends MapperTemplate {
         //修改返回值类型为实体类型
         setResultType(ms, entityClass);
         StringBuilder sql = new StringBuilder();
+        if (getConfig().isSafeSelect()) {
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getColumns(entityClass), isNotEmpty()));
+        }
         sql.append(SqlHelper.selectAllColumns(entityClass));
         sql.append(SqlHelper.fromTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.whereAllIfColumns(entityClass, isNotEmpty()));
@@ -68,6 +72,9 @@ public class BaseSelectProvider extends MapperTemplate {
         //修改返回值类型为实体类型
         setResultType(ms, entityClass);
         StringBuilder sql = new StringBuilder();
+        if (getConfig().isSafeSelect()) {
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getColumns(entityClass), isNotEmpty()));
+        }
         sql.append(SqlHelper.selectAllColumns(entityClass));
         sql.append(SqlHelper.fromTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.whereAllIfColumns(entityClass, isNotEmpty()));
@@ -110,6 +117,9 @@ public class BaseSelectProvider extends MapperTemplate {
     public String selectCount(MappedStatement ms) {
         Class<?> entityClass = getEntityClass(ms);
         StringBuilder sql = new StringBuilder();
+        if (getConfig().isSafeSelect()) {
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getColumns(entityClass), isNotEmpty()));
+        }
         sql.append(SqlHelper.selectCount(entityClass));
         sql.append(SqlHelper.fromTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.whereAllIfColumns(entityClass, isNotEmpty()));

--- a/base/src/main/java/tk/mybatis/mapper/provider/base/BaseUpdateProvider.java
+++ b/base/src/main/java/tk/mybatis/mapper/provider/base/BaseUpdateProvider.java
@@ -25,6 +25,7 @@
 package tk.mybatis.mapper.provider.base;
 
 import org.apache.ibatis.mapping.MappedStatement;
+import tk.mybatis.mapper.mapperhelper.EntityHelper;
 import tk.mybatis.mapper.mapperhelper.MapperHelper;
 import tk.mybatis.mapper.mapperhelper.MapperTemplate;
 import tk.mybatis.mapper.mapperhelper.SqlHelper;
@@ -48,6 +49,9 @@ public class BaseUpdateProvider extends MapperTemplate {
     public String updateByPrimaryKey(MappedStatement ms) {
         Class<?> entityClass = getEntityClass(ms);
         StringBuilder sql = new StringBuilder();
+        if (getConfig().isSafeUpdate()) {
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getPKColumns(entityClass), isNotEmpty()));
+        }
         sql.append(SqlHelper.updateTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.updateSetColumns(entityClass, null, false, false));
         sql.append(SqlHelper.wherePKColumns(entityClass, true));
@@ -63,6 +67,9 @@ public class BaseUpdateProvider extends MapperTemplate {
     public String updateByPrimaryKeySelective(MappedStatement ms) {
         Class<?> entityClass = getEntityClass(ms);
         StringBuilder sql = new StringBuilder();
+        if (getConfig().isSafeUpdate()) {
+            sql.append(SqlHelper.notAllNullParameterCheck("_parameter", EntityHelper.getPKColumns(entityClass), isNotEmpty()));
+        }
         sql.append(SqlHelper.updateTable(entityClass, tableName(entityClass)));
         sql.append(SqlHelper.updateSetColumns(entityClass, null, true, isNotEmpty()));
         sql.append(SqlHelper.wherePKColumns(entityClass, true));

--- a/base/src/test/java/tk/mybatis/mapper/base/delete/SafeDeleteByFieldTest.java
+++ b/base/src/test/java/tk/mybatis/mapper/base/delete/SafeDeleteByFieldTest.java
@@ -15,6 +15,7 @@ public class SafeDeleteByFieldTest extends BaseTest {
     protected Config getConfig() {
         Config config = super.getConfig();
         config.setSafeDelete(true);
+        config.setNotEmpty(true);
         return config;
     }
 
@@ -41,6 +42,19 @@ public class SafeDeleteByFieldTest extends BaseTest {
     }
 
     @Test(expected = PersistenceException.class)
+    public void testSafeDeleteEmptyString() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Country country = new Country();
+            country.setCountryname("");
+            mapper.delete(country);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
     public void testSafeDeleteByExample() {
         SqlSession sqlSession = getSqlSession();
         try {
@@ -57,6 +71,19 @@ public class SafeDeleteByFieldTest extends BaseTest {
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
             mapper.deleteByExample(null);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeDeleteByExampleWithEmptyStringCriterion() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = new Example(Country.class);
+            example.createCriteria().andEqualTo("countryname", "");
+            mapper.deleteByExample(example);
         } finally {
             sqlSession.close();
         }

--- a/base/src/test/java/tk/mybatis/mapper/base/delete/SafeDeleteByMethodTest.java
+++ b/base/src/test/java/tk/mybatis/mapper/base/delete/SafeDeleteByMethodTest.java
@@ -15,6 +15,7 @@ public class SafeDeleteByMethodTest extends BaseTest {
     protected Config getConfig() {
         Config config = super.getConfig();
         config.setSafeDelete(true);
+        config.setNotEmpty(true);
         //和 SafeDeleteByFieldTest 测试的区别在此，这里将会使后面调用 EntityField.getValue 时，使用 getter 方法获取值
         config.setEnableMethodAnnotation(true);
         return config;
@@ -42,6 +43,19 @@ public class SafeDeleteByMethodTest extends BaseTest {
         }
     }
 
+    @Test(expected = PersistenceException.class)
+    public void testSafeDeleteEmptyString() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Country country = new Country();
+            country.setCountryname("");
+            mapper.delete(country);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
 
     @Test(expected = PersistenceException.class)
     public void testSafeDeleteByExample() {
@@ -60,6 +74,19 @@ public class SafeDeleteByMethodTest extends BaseTest {
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
             mapper.deleteByExample(null);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeDeleteByExampleWithEmptyStringCriterion() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = new Example(Country.class);
+            example.createCriteria().andEqualTo("countryname", "");
+            mapper.deleteByExample(example);
         } finally {
             sqlSession.close();
         }

--- a/base/src/test/java/tk/mybatis/mapper/base/select/SafeSelectByFieldTest.java
+++ b/base/src/test/java/tk/mybatis/mapper/base/select/SafeSelectByFieldTest.java
@@ -1,113 +1,142 @@
-package tk.mybatis.mapper.base.update;
+package tk.mybatis.mapper.base.select;
 
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.session.SqlSession;
+import org.junit.Assert;
 import org.junit.Test;
 import tk.mybatis.mapper.base.BaseTest;
 import tk.mybatis.mapper.base.Country;
 import tk.mybatis.mapper.base.CountryMapper;
 import tk.mybatis.mapper.entity.Config;
 import tk.mybatis.mapper.entity.Example;
+import tk.mybatis.mapper.entity.model.CountryExample;
 
-public class SafeUpdateByMethodTest extends BaseTest {
+public class SafeSelectByFieldTest extends BaseTest {
 
     @Override
     protected Config getConfig() {
         Config config = super.getConfig();
-        config.setSafeUpdate(true);
-        //和 SafeUpdateByFieldTest 测试的区别在此，这里将会使后面调用 EntityField.getValue 时，使用 getter 方法获取值
-        config.setEnableMethodAnnotation(true);
+        config.setSafeSelect(true);
+        config.setNotEmpty(true);
         return config;
     }
 
     @Test(expected = PersistenceException.class)
-    public void testSafeUpdateByPrimaryKeyNull() {
+    public void testSafeSelect() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByPrimaryKey(new Country());
+            mapper.select(new Country());
         } finally {
             sqlSession.close();
         }
     }
 
     @Test(expected = PersistenceException.class)
-    public void testSafeUpdateByPrimaryKeySelectiveNull() {
+    public void testSafeSelectNull() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByPrimaryKeySelective(new Country());
+            mapper.select(null);
         } finally {
             sqlSession.close();
         }
     }
 
     @Test(expected = PersistenceException.class)
-    public void testSafeUpdate() {
+    public void testSafeSelectEmptyString() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByExample(new Country(), new Example(Country.class));
+            Country country = new Country();
+            country.setCountryname("");
+            mapper.select(country);
         } finally {
             sqlSession.close();
         }
     }
 
     @Test(expected = PersistenceException.class)
-    public void testSafeUpdateWithEmptyStringCriterion() {
+    public void testSafeSelectCountEmptyString() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Country country = new Country();
+            country.setCountryname("");
+            mapper.selectCount(country);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeSelectByExample() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            mapper.selectByExample(new Example(Country.class));
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeSelectByExampleNull() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            mapper.selectByExample(null);
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeSelectByExampleWithEmptyStringCriterion() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
             Example example = new Example(Country.class);
             example.createCriteria().andEqualTo("countryname", "");
-            mapper.updateByExample(new Country(), example);
+            mapper.selectByExample(example);
         } finally {
             sqlSession.close();
         }
     }
 
     @Test(expected = PersistenceException.class)
-    public void testSafeUpdateNull() {
+    public void testSafeSelectByGeneratedExampleWithEmptyStringCriterion() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByExample(new Country(), null);
+            CountryExample example = new CountryExample();
+            example.createCriteria().andCountrynameEqualTo("");
+            mapper.selectByExample(example);
         } finally {
             sqlSession.close();
         }
     }
 
-    @Test(expected = PersistenceException.class)
-    public void testSafeUpdateNull2() {
+    @Test
+    public void testSafeSelectWithCondition() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByExample(null, null);
+            Country country = new Country();
+            country.setCountryname("China");
+            Assert.assertEquals(1, mapper.select(country).size());
+
+            Example example = new Example(Country.class);
+            example.createCriteria().andEqualTo("countryname", "China");
+            Assert.assertEquals(1, mapper.selectByExample(example).size());
+
+            CountryExample generatedExample = new CountryExample();
+            generatedExample.createCriteria().andCountrynameEqualTo("China");
+            Assert.assertEquals(1, mapper.selectByExample(generatedExample).size());
+
+            Assert.assertEquals(183, mapper.selectAll().size());
         } finally {
             sqlSession.close();
         }
     }
-
-    @Test(expected = PersistenceException.class)
-    public void testSafeUpdateByExample() {
-        SqlSession sqlSession = getSqlSession();
-        try {
-            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByExampleSelective(new Country(), new Example(Country.class));
-        } finally {
-            sqlSession.close();
-        }
-    }
-
-    @Test(expected = PersistenceException.class)
-    public void testSafeUpdateByExampleNull() {
-        SqlSession sqlSession = getSqlSession();
-        try {
-            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
-            mapper.updateByExampleSelective(new Country(), null);
-        } finally {
-            sqlSession.close();
-        }
-    }
-
 }

--- a/base/src/test/java/tk/mybatis/mapper/base/update/SafeUpdateByFieldTest.java
+++ b/base/src/test/java/tk/mybatis/mapper/base/update/SafeUpdateByFieldTest.java
@@ -19,11 +19,46 @@ public class SafeUpdateByFieldTest extends BaseTest {
     }
 
     @Test(expected = PersistenceException.class)
+    public void testSafeUpdateByPrimaryKeyNull() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            mapper.updateByPrimaryKey(new Country());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeUpdateByPrimaryKeySelectiveNull() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            mapper.updateByPrimaryKeySelective(new Country());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
     public void testSafeUpdate() {
         SqlSession sqlSession = getSqlSession();
         try {
             CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
             mapper.updateByExample(new Country(), new Example(Country.class));
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void testSafeUpdateWithEmptyStringCriterion() {
+        SqlSession sqlSession = getSqlSession();
+        try {
+            CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+            Example example = new Example(Country.class);
+            example.createCriteria().andEqualTo("countryname", "");
+            mapper.updateByExample(new Country(), example);
         } finally {
             sqlSession.close();
         }

--- a/core/src/main/java/tk/mybatis/mapper/entity/Config.java
+++ b/core/src/main/java/tk/mybatis/mapper/entity/Config.java
@@ -87,6 +87,10 @@ public class Config {
      */
     private boolean safeUpdate;
     /**
+     * 安全查询，开启后，不允许执行不带查询条件的条件查询方法
+     */
+    private boolean safeSelect;
+    /**
      * 控制通过主键进行操作（select, update, delete）时，是否拼接逻辑删除字段的条件（默认 true，保持兼容）
      * <p>
      * 设置为 false 时，通过主键查询或操作时不会追加 logicDeleteField = 0 的条件
@@ -318,6 +322,14 @@ public class Config {
         this.safeUpdate = safeUpdate;
     }
 
+    public boolean isSafeSelect() {
+        return safeSelect;
+    }
+
+    public void setSafeSelect(boolean safeSelect) {
+        this.safeSelect = safeSelect;
+    }
+
     public boolean isLogicDeleteByKey() {
         return logicDeleteByKey;
     }
@@ -423,6 +435,8 @@ public class Config {
         this.safeDelete = Boolean.valueOf(properties.getProperty("safeDelete"));
         //safeUpdate
         this.safeUpdate = Boolean.valueOf(properties.getProperty("safeUpdate"));
+        //safeSelect
+        this.safeSelect = Boolean.valueOf(properties.getProperty("safeSelect"));
         // 控制通过主键进行操作（select, update, delete）时，是否拼接逻辑删除字段的条件（默认 true，保持兼容）
         String logicDeleteByKey = properties.getProperty("logicDeleteByKey");
         if (StringUtil.isNotEmpty(logicDeleteByKey)) {

--- a/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
+++ b/core/src/main/java/tk/mybatis/mapper/mapperhelper/SqlHelper.java
@@ -576,6 +576,18 @@ public class SqlHelper {
      * @return
      */
     public static String notAllNullParameterCheck(String parameterName, Set<EntityColumn> columnSet) {
+        return notAllNullParameterCheck(parameterName, columnSet, false);
+    }
+
+    /**
+     * 不是所有参数都是 null 或空字符串的检查
+     *
+     * @param parameterName 参数名
+     * @param columnSet     需要检查的列
+     * @param notEmpty      是否判断 String 类型 != ''
+     * @return
+     */
+    public static String notAllNullParameterCheck(String parameterName, Set<EntityColumn> columnSet, boolean notEmpty) {
         StringBuilder sql = new StringBuilder();
         sql.append("<bind name=\"notAllNullParameterCheck\" value=\"@tk.mybatis.mapper.util.OGNL@notAllNullParameterCheck(");
         sql.append(parameterName).append(", '");
@@ -587,7 +599,9 @@ public class SqlHelper {
             fields.append(column.getProperty());
         }
         sql.append(fields);
-        sql.append("')\"/>");
+        sql.append("', ");
+        sql.append(notEmpty);
+        sql.append(")\"/>");
         return sql.toString();
     }
 
@@ -598,9 +612,22 @@ public class SqlHelper {
      * @return
      */
     public static String exampleHasAtLeastOneCriteriaCheck(String parameterName) {
+        return exampleHasAtLeastOneCriteriaCheck(parameterName, true);
+    }
+
+    /**
+     * Example 中包含至少 1 个查询条件，且查询条件的值不能为空
+     *
+     * @param parameterName 参数名
+     * @param notEmpty      是否判断 String 类型 != ''，Example 安全检查中建议使用 true
+     * @return
+     */
+    public static String exampleHasAtLeastOneCriteriaCheck(String parameterName, boolean notEmpty) {
         StringBuilder sql = new StringBuilder();
         sql.append("<bind name=\"exampleHasAtLeastOneCriteriaCheck\" value=\"@tk.mybatis.mapper.util.OGNL@exampleHasAtLeastOneCriteriaCheck(");
-        sql.append(parameterName).append(")\"/>");
+        sql.append(parameterName).append(", ");
+        sql.append(notEmpty);
+        sql.append(")\"/>");
         return sql.toString();
     }
 

--- a/core/src/main/java/tk/mybatis/mapper/util/OGNL.java
+++ b/core/src/main/java/tk/mybatis/mapper/util/OGNL.java
@@ -32,6 +32,7 @@ import tk.mybatis.mapper.entity.IDynamicTableName;
 import tk.mybatis.mapper.mapperhelper.EntityHelper;
 import tk.mybatis.mapper.mapperhelper.SqlHelper;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.*;
 
@@ -71,18 +72,32 @@ public abstract class OGNL {
      * @return
      */
     public static boolean notAllNullParameterCheck(Object parameter, String fields) {
+        return notAllNullParameterCheck(parameter, fields, false);
+    }
+
+    /**
+     * 检查 parameter 对象中指定的 fields 是否全是 null 或空字符串，如果是则抛出异常
+     *
+     * @param parameter
+     * @param fields
+     * @param notEmpty
+     * @return
+     */
+    public static boolean notAllNullParameterCheck(Object parameter, String fields, boolean notEmpty) {
         if (parameter != null) {
             try {
                 Set<EntityColumn> columns = EntityHelper.getColumns(parameter.getClass());
                 Set<String> fieldSet = new HashSet<String>(Arrays.asList(fields.split(",")));
                 for (EntityColumn column : columns) {
-                    if (fieldSet.contains(column.getProperty())) {
+                    if (fieldSet.contains(column.getProperty()) && !isLogicDeleteColumn(column)) {
                         Object value = column.getEntityField().getValue(parameter);
-                        if (value != null) {
+                        if (isEffectiveValue(value, notEmpty)) {
                             return true;
                         }
                     }
                 }
+            } catch (MapperException e) {
+                throw e;
             } catch (Exception e) {
                 throw new MapperException(SAFE_DELETE_ERROR, e);
             }
@@ -111,36 +126,145 @@ public abstract class OGNL {
      * @return
      */
     public static boolean exampleHasAtLeastOneCriteriaCheck(Object parameter) {
+        return exampleHasAtLeastOneCriteriaCheck(parameter, true);
+    }
+
+    public static boolean exampleHasAtLeastOneCriteriaCheck(Object parameter, boolean notEmpty) {
         if (parameter != null) {
             try {
-                if (parameter instanceof Example) {
-                    List<Example.Criteria> criteriaList = ((Example) parameter).getOredCriteria();
-                    if (criteriaList != null && criteriaList.size() > 0) {
-                        for (Example.Criteria criteria : criteriaList) {
-                            if (criteria != null && criteria.isValid()) {
-                                return true;
-                            }
+                List<?> criteriaList = getOredCriteria(parameter);
+                if (criteriaList != null && criteriaList.size() > 0) {
+                    boolean hasCriterion = false;
+                    for (Object criteria : criteriaList) {
+                        if (criteriaHasCriterion(criteria, notEmpty)) {
+                            hasCriterion = true;
                         }
                     }
-                } else {
-                    Method getter = parameter.getClass().getDeclaredMethod("getOredCriteria");
-                    Object list = getter.invoke(parameter);
-                    if (list != null && list instanceof List) {
-                        List criteriaList = (List) list;
-                        if (criteriaList.size() > 0) {
-                            for (Object criteria : criteriaList) {
-                                if (criteria instanceof Example.Criteria && ((Example.Criteria) criteria).isValid()) {
-                                    return true;
-                                }
-                            }
-                        }
+                    if (hasCriterion) {
+                        return true;
                     }
                 }
+            } catch (MapperException e) {
+                throw e;
             } catch (Exception e) {
                 throw new MapperException(SAFE_DELETE_ERROR, e);
             }
         }
         throw new MapperException(SAFE_DELETE_EXCEPTION);
+    }
+
+    private static List<?> getOredCriteria(Object parameter) throws Exception {
+        if (parameter instanceof Example) {
+            return ((Example) parameter).getOredCriteria();
+        }
+        Method getter = parameter.getClass().getMethod("getOredCriteria");
+        if (!getter.isAccessible()) {
+            getter.setAccessible(true);
+        }
+        Object list = getter.invoke(parameter);
+        if (list instanceof List) {
+            return (List<?>) list;
+        }
+        return null;
+    }
+
+    private static boolean criteriaHasCriterion(Object criteria, boolean notEmpty) throws Exception {
+        if (criteria == null) {
+            return false;
+        }
+        List<?> criterionList = getCriteriaList(criteria);
+        if (criterionList != null) {
+            boolean hasCriterion = false;
+            for (Object criterion : criterionList) {
+                if (criterion != null) {
+                    emptyCriterionValueCheck(criterion, notEmpty);
+                    hasCriterion = true;
+                }
+            }
+            return hasCriterion;
+        }
+        Boolean valid = invokeBoolean(criteria, "isValid");
+        return valid != null && valid;
+    }
+
+    private static List<?> getCriteriaList(Object criteria) throws Exception {
+        if (criteria instanceof Example.Criteria) {
+            return ((Example.Criteria) criteria).getAllCriteria();
+        }
+        Object list = invoke(criteria, "getAllCriteria");
+        if (list instanceof List) {
+            return (List<?>) list;
+        }
+        list = invoke(criteria, "getCriteria");
+        if (list instanceof List) {
+            return (List<?>) list;
+        }
+        return null;
+    }
+
+    private static void emptyCriterionValueCheck(Object criterion, boolean notEmpty) throws Exception {
+        Boolean noValue = invokeBoolean(criterion, "isNoValue");
+        if (Boolean.TRUE.equals(noValue)) {
+            return;
+        }
+        Boolean singleValue = invokeBoolean(criterion, "isSingleValue");
+        if (Boolean.TRUE.equals(singleValue) && isEmptyConditionValue(invoke(criterion, "getValue"), notEmpty)) {
+            throw new MapperException(SAFE_DELETE_EXCEPTION);
+        }
+        Boolean betweenValue = invokeBoolean(criterion, "isBetweenValue");
+        if (Boolean.TRUE.equals(betweenValue)
+                && (isEmptyConditionValue(invoke(criterion, "getValue"), notEmpty)
+                || isEmptyConditionValue(invoke(criterion, "getSecondValue"), notEmpty))) {
+            throw new MapperException(SAFE_DELETE_EXCEPTION);
+        }
+        Boolean listValue = invokeBoolean(criterion, "isListValue");
+        if (Boolean.TRUE.equals(listValue) && isEmptyConditionValue(invoke(criterion, "getValue"), notEmpty)) {
+            throw new MapperException(SAFE_DELETE_EXCEPTION);
+        }
+    }
+
+    private static Boolean invokeBoolean(Object target, String methodName) throws Exception {
+        Object value = invoke(target, methodName);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return null;
+    }
+
+    private static Object invoke(Object target, String methodName) throws Exception {
+        try {
+            Method method = target.getClass().getMethod(methodName);
+            if (!method.isAccessible()) {
+                method.setAccessible(true);
+            }
+            return method.invoke(target);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static boolean isLogicDeleteColumn(EntityColumn column) {
+        return column.getEntityField().isAnnotationPresent(LogicDelete.class);
+    }
+
+    private static boolean isEffectiveValue(Object value, boolean notEmpty) {
+        return !isEmptyConditionValue(value, notEmpty);
+    }
+
+    private static boolean isEmptyConditionValue(Object value, boolean notEmpty) {
+        if (value == null) {
+            return true;
+        }
+        if (notEmpty && value instanceof String && StringUtil.isEmpty((String) value)) {
+            return true;
+        }
+        if (value instanceof Collection && ((Collection) value).isEmpty()) {
+            return true;
+        }
+        if (value.getClass().isArray() && Array.getLength(value) == 0) {
+            return true;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

Add a safe select option and extend safe condition validation to avoid accidental full-table operations when upstream passes empty parameters.

- add safeSelect configuration and wire it into object and Example select providers
- require object-based CRUD safety checks to have at least one effective WHERE condition
- make Example safety checks reject empty condition values, including null, empty string, empty collection, and empty array
- cover tk.mybatis Example and generated Example styles in tests

## Validation

- mvn -pl base -am -Dtest=SafeSelectByFieldTest,SafeDeleteByFieldTest,SafeDeleteByMethodTest,SafeUpdateByFieldTest,SafeUpdateByMethodTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test
- mvn -pl base -am -DfailIfNoTests=false test
- git diff --check